### PR TITLE
Do autostart only when data-bibi-autostart is true

### DIFF
--- a/bib/i.js
+++ b/bib/i.js
@@ -82,7 +82,7 @@ Pipi = { /*!
 			var ID        = As[i].getAttribute("data-bibi-id");
 			var Style     = As[i].getAttribute("data-bibi-style");
 			var Poster    = As[i].getAttribute("data-bibi-poster");
-			var Autostart = As[i].getAttribute("data-bibi-autostart");
+			var Autostart = As[i].getAttribute("data-bibi-autostart") === "true";
 			if(Class) Holder.className += " " + Class;
 			if(ID)    Holder.id = ID;
 			if(Style) Holder.setAttribute("style", Style);


### PR DESCRIPTION
@satorumurmur 
Hi,

I found setting `data-bibi-autostart="false"` doesn't follow expected behavior, don't autostart, on embedding style:

```html
<a
  autostart="false"
  href="http://your.web.site/somewhere/bib/i/?book=my-book.epub"
  data-bibi="embed"
  data-bibi-style="[[ CSS for embeded BiB/i, as you like ]]">
  My Great Book Title
</a>
<script src="http://your.web.site/bib/i.js"></script>
```

I think we should fix this behavior. If you agree with me, we have, I think, two choices: `aria-*`'s `true`/`false` way and `video`'s `autoplay` way.

### WAI-ARIA's way ###

Now default value of `bibi-data-autostart` is `false`, so, we set it to `true` only when `data-bibi-autostart` attributes' value is exactly the same to the string `true`. Even if it is set to `yes`, we evaluate it as `false`.

Fix for this is in this pull request.

### `video` element's way ###

We assume `autostart` is `true` if `a` element has the attribute `data-bibi-autostart`(we can test it by `hasAttribute` method), even when it is the string `false` like `video`'s `autoplay` attribute.

I prefer this way because probably most of people who write HTML code are familiar with this than WAI-ARIA's way.

But I guess you might like WAI-ARIA's way, so, it is used in this pull request.
Could you consider this issue?

