### PR TITLE
holderadded event

### DIFF
--- a/bib/i.js
+++ b/bib/i.js
@@ -1,3 +1,17 @@
+if (typeof window.CustomEvent === "undefined") {
+	window.CustomEvent = function(EventName, Args) {
+		Args = Args || {
+			bubbles:    false,
+			cancelable: false,
+			detail:     undefined
+		};
+		var Event = document.createEvent("CustomEvent");
+		Event.initCustomEvent(EventName, Args.bubbles, Args.cancelable, Args.detail);
+		return Event;
+	};
+	window.CustomEvent.prototype = window.Event.prototype;
+}
+
 Pipi = { /*!
  *
  *  # Pipi: BiB/i Putter

--- a/bib/i.js
+++ b/bib/i.js
@@ -135,6 +135,13 @@ Pipi = { /*!
 				);
 			}
 			window["bibi-pipi"].Holders.push(Holder);
+			As[i].dispatchEvent(
+				new CustomEvent("bibi:holderadded", {
+					bubbles:    true,
+					cancelable: true,
+					detail:     { holder: Holder }
+				})
+			);
 		}
 	}
 	window["bibi-pipi"].Status = "processed";


### PR DESCRIPTION
@satorumurmur 
Hi,

I think it's helpful if we can know when BiB/i's holder `span` element is added to DOM tree
so that we can find and manipulate it safely.
This pull request is for that needs.

Of course, there are something to consider carefully like event name(`holderadded`), namespace(`bibi:`) and timing to dispatch.
But, can you start with consideration whether BiB/i should have event API or not?
I will rewrite patch if needed.

Thanks.