### PR TITLE
Reduce HTTP request payload

### DIFF
--- a/dev-bib/i/res/scripts/bibi.heart.js
+++ b/dev-bib/i/res/scripts/bibi.heart.js
@@ -322,7 +322,7 @@ L.loadBook = function(PathOrData) {
             // Online
             if(!P["trustworthy-origins"].includes(PathOrData.Path.replace(/^([\w\d]+:\/\/[^\/]+).*$/, "$1"))) return L.loadBook.reject('The Origin of the Path of the Book Is Not Allowed.');
             B.Path = PathOrData.Path;
-            O.download(B.Path + "/mimetype").then(function() {
+            O.download(B.Path + "/" + B.Container.Path).then(function() {
                 // Online && Unzipped
                 B.Unzipped = true;
                 O.log('EPUB: ' + B.Path + ' (Unzipped Online Folder)', "-*");


### PR DESCRIPTION
Using `/META-INF/container.xml` instead of `/mimetype` to guess whether given book is packaged or not reduces HTTP request payload because `/META-INF/container.xml` is cached.
![](https://gyazo.com/f08069623cb7c64dcff5ee86aee451c3.png)

It's  better if the response is cached to JavaScript object and reused later, but this patch doesn't make anything worse.