### PR TITLE
Pass '.' as a basedir to BrowserSync.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -378,7 +378,7 @@ S.Extensions.forEach(function(ExtensionName) {
 gulp.task('serve', function() {
     $.browserSync({
         server: {
-            baseDir: '',
+            baseDir: '.',
             index: 'index.html'
         },
         ghostMode: {


### PR DESCRIPTION
BaseDirが空白だと全てのファイルで404が帰ってきてしまうようです。
'.'を渡すと意図通り、HTMLやCSSを返してくれるようになります。