### PR TITLE
fix bug where loading bibi.book.css fails when index.html opened as a local file

### DIFF
--- a/dev-bib/i/res/scripts/bibi.heart.js
+++ b/dev-bib/i/res/scripts/bibi.heart.js
@@ -936,7 +936,14 @@ L.coordinateLinkages = (BasePath, RootElement, InNav) => {
 L.preprocessResources = () => new Promise((resolve, reject) => {
     E.dispatch('bibi:is-going-to:preprocess-resources');
     const PpdReses = []; // PreprocessedResources
-    const Promises = [O.download({ Path: new URL('res/styles/bibi.book.css', O.RootPath + '/').pathname, 'media-type': 'text/css', Bibitem: true }).then(O.getBlobURL).then(Item => {
+    const Promises = [(new Promise(resolveItem => {
+        const Item = { Path: new URL('res/styles/bibi.book.css', O.RootPath + '/').pathname, 'media-type': 'text/css', Bibitem: true };
+        const tempLink = sML.create('link', { href: Item.Path, rel: 'stylesheet', onload: () => {
+            resolveItem(Item);
+            document.head.removeChild(tempLink);
+        }});
+        document.head.appendChild(tempLink);
+    })).then(Item => {
         Item.Content = '';
         B.DefaultStyle = Item;
         return PpdReses.push(B.DefaultStyle);


### PR DESCRIPTION
README indicates "you can read in browsers on your local machine". However, the xhr loading of `bibi.book.css` file fails and cannot be used.

To enable on the local machine, this pull request replaces xhr loading with `<link>` and `onload`.