### PR TITLE
typo in is-ppis feature. An error occurred when "#bibi (si-ppis:...)" was used

### DIFF
--- a/__src/bibi/resources/scripts/bibi.heart.js
+++ b/__src/bibi/resources/scripts/bibi.heart.js
@@ -4611,7 +4611,7 @@ U.initialize = () => { // formerly O.readExtras
                     if(/^[1-9][0-9]*$/.test(PnV[1])) PnV[1] *= 1; else return;
                     break;
                 case 'si-ppis':
-                    if(/^\d+\-(0(\.\d+)*|1)$/.test(PnV[1])) PnV[1] = { 'SI-PPiS': Pnv[1] }; else return;
+                    if(/^\d+\-(0(\.\d+)*|1)$/.test(PnV[1])) PnV[1] = { 'SI-PPiS': PnV[1] }; else return;
                     break;
                 case 'horizontal':
                 case 'vertical':


### PR DESCRIPTION
An error occurred when "#bibi (si-ppis:...)" was used  as a URL hash.
The browser displays "ReferenceError: Pnv is not defined".
"Pnv" is a typo. Must be "PnV"

![si-ppis-error](https://user-images.githubusercontent.com/9836533/74605626-1f504380-510d-11ea-8390-ce457404398e.jpg)
