### PR TITLE
Fix Webpack config for Win development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const Webpack = require('webpack');
+const path = require('path');
 
 const Package = require('./package.json');
 const Bibi = require('./bibi.info.js');
@@ -103,7 +104,11 @@ const Config = {
             }
         }]
     }, {
-        test: /\/(bibi\.heart|jo)\.js$/,
+        test: /(bibi\.heart|jo)\.js$/,
+        include: [
+            path.resolve(__dirname, '__src/bibi/and'),
+            path.resolve(__dirname, '__src/bibi/resources/scripts')
+        ],
         use: [
             StringReplacePlugin.replace({ replacements: [{
                 pattern: /____Bibi-Version____/ig,
@@ -137,7 +142,10 @@ const Config = {
     ];
     Config.module.rules.push({
         test: /\.scss$/,
-        exclude: /\/(bibi\.book|jo)\.scss$/,
+        exclude: [
+            path.resolve(__dirname, '__src/bibi/resources/scripts/bibi.book.scss'),
+            path.resolve(__dirname, '__src/bibi/and/jo.scss')
+        ],
         use: [
             MiniCSSExtractPlugin.loader,
             StringReplacePlugin.replace({ replacements: [{
@@ -147,13 +155,20 @@ const Config = {
         ].concat(CommonLoadersForCSS)
     });
     Config.module.rules.push({
-        test: /\/(bibi\.book|jo)\.scss$/,
+        test: /\.scss$/,
+        include: [
+            path.resolve(__dirname, '__src/bibi/resources/scripts/bibi.book.scss'),
+            path.resolve(__dirname, '__src/bibi/and/jo.scss')
+        ],
         use: [
             { loader: 'style-loader' }
         ].concat(CommonLoadersForCSS)
     });
     Config.module.rules.push({
-        test: /\/MaterialIcons-Regular\.(eot|svg|ttf|wof|woff|woff2)$/,
+        test: /MaterialIcons-Regular\.(eot|svg|ttf|wof|woff|woff2)$/,
+        include: [
+            path.resolve(__dirname, 'node_modules/material-icons/iconfont')
+        ],
         use: [
             { loader: 'file-loader', options: {
                 outputPath: 'bibi/resources/styles/fonts',


### PR DESCRIPTION
Hey, there!
Dev server starts smoothly on MacOS. But one of my colleagues had issues on Windows 10.
Projects doesn't compile on his machine with complain on `bibi.scss` file:

> `ERROR in ./__src/bibi/resources/styles/bibi.scss`
`ModuleParseError: Module parse failed: Unexpected character ' '(1:0)`
`You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file.`

I think that this issue related to forward slash in rules patterns. I've changed Webpack config a bit and now compilation ends without errors. `npm run build` command also without errors.