### PR TITLE
Fix for Windows.Web.IUriToStreamResolver

### DIFF
--- a/__src/bibi/resources/scripts/bibi.heart.js
+++ b/__src/bibi/resources/scripts/bibi.heart.js
@@ -491,7 +491,7 @@ L.initializeBook = (Par) => new Promise((resolve, reject) => {
     if(!Par || !Par.BookData) return reject(`Book Data Is Undefined.`);
     let BookData = Par.BookData;
     const BookDataFormat =
-        typeof BookData == 'string' ? (/^https?:\/\//.test(BookData) ? 'URI' : 'Base64') :
+        typeof BookData == 'string' ? (/^https?:\/\//.test(BookData) || /^ms-local-stream:\/\//.test(BookData) ? 'URI' : 'Base64') :
         typeof BookData == 'object' ? (BookData instanceof File ? 'File' : BookData instanceof Blob ? 'BLOB' : '') : '';
     if(!BookDataFormat) return reject(`Book Data Is Unknown.`);
     if(BookDataFormat == 'URI') {


### PR DESCRIPTION
[WebView.NavigateToLocalStreamUri](https://docs.microsoft.com/ja-jp/uwp/api/windows.ui.xaml.controls.webview.navigatetolocalstreamuri#Windows_UI_Xaml_Controls_WebView_NavigateToLocalStreamUri_Windows_Foundation_Uri_Windows_Web_IUriToStreamResolver_)で利用する際に、上記部分の修正が必要でした。
これはUWP(Universal Windows Platform)でローカル生成したウェブコンテンツを表示する機能で、URLは"ms-local-stream://"で始まります。（[利用元](https://github.com/kurema/BookViewerApp3/blob/master/BookViewerApp/Views/EpubResolver.cs)）。

HTML版を普通のアプリ内蔵ビュワーとして使うことは考えられますし、その場合スキーム名が``https?//``ではない事も多いはずです。

一々ホワイトリストで追加するのもおかしいですし、
```
typeof BookData == 'string' ? (/^data:/.test(BookData) ? 'Base64' : 'URI') :
```
で問題ないならその方が良いと思います。
こうなっているのは何か理由があると考えて、UWP向けの修正だけを行っています。