### PR TITLE
Make bibi:commands:focus-on works

### DIFF
--- a/__src/bibi/resources/scripts/bibi.heart.js
+++ b/__src/bibi/resources/scripts/bibi.heart.js
@@ -1892,7 +1892,7 @@ Object.defineProperties(R, { // To ensure backward compatibility.
 
 R.focusOn = (Par) => new Promise((resolve, reject) => {
     if(R.Moving) return reject();
-    if(typeof Par == 'number') Par = { Destination: Par };
+    if(typeof Par == 'number' || /^\d+$/.test(Par)) Par = { Destination: Par };
     if(!Par) return reject();
     const _ = Par.Destination = R.hatchDestination(Par.Destination);
     if(!_) return reject();


### PR DESCRIPTION
Hi,

Now `bibi:commands:focus-on` command doesn't work because its argument is sent as string but `R.focusOn` expects number. I fixed this and `Bibi.post('bibi:commands:focus-on', 12)` works after this patch is merged.

Can you review it?

Thanks.